### PR TITLE
map_frankfurt: remove invalid exitUrl

### DIFF
--- a/map_frankfurt.json
+++ b/map_frankfurt.json
@@ -145,12 +145,6 @@
          "id":20,
          "name":"portal-to-hub-top",
          "opacity":1,
-         "properties":[
-                {
-                 "name":"exitUrl",
-                 "type":"string",
-                 "value":"\/_\/global\/raw.githubusercontent.com\/itemis-Nord\/ces-workadventure-maps\/cloud-hub\/hub\/hub.json#portal-from-frankfurt"
-                }],
          "type":"tilelayer",
          "visible":true,
          "width":46,


### PR DESCRIPTION
The correct exitUrl exists in layer portal-to-hub, the wrong url from
portal-to-hub-top should be dropped.